### PR TITLE
dev

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -8,8 +8,6 @@ fi
 ZDIR=~/.config/zsh
 
 ZSH_THEME="powerlevel10k/powerlevel10k"
-# Because powerlevel10k doesn't magically start at the bottom :(
-printf '\n%.0s' {1..100}
 
 # Uncomment the following line to use hyphen-insensitive completion.
 # Case-sensitive completion must be off. _ and - will be interchangeable.
@@ -79,4 +77,6 @@ else
   [[ ! -f $ZDOTDIR/.p10k.zsh ]] || source $ZDOTDIR/.p10k.zsh
 fi
 
+# terminal starts with prompt at bottom then runs helpmessage
+prompt-at-bottom
 helpmessage

--- a/omz-files/zsh_aliases.zsh
+++ b/omz-files/zsh_aliases.zsh
@@ -14,6 +14,7 @@ alias z='cd $ZDOTDIR'
 alias zdir="$ZDOTDIR/"
 alias update-db="sudo updatedb --prunepaths='/timeshift/snapshots /media /run/timeshift /run/user'"
 alias e='echo'
+alias cls='clear && prompt-at-bottom'
 alias s='sudo'
 alias cpd='cp -r'
 alias cpd-ffs='sudo cp -r'
@@ -70,6 +71,12 @@ helpmessage() {
     echo 'Use `z` to change to $ZDOTDIR.\nYou can use `own` `owndir` to take ownership of files and directories, respectively.'
     echo 'NOTE: `owndir` recursively gives you ownership of ALL files in a directory.'
   fi
+}
+
+# This is because I'm using transient prompt and my prompt
+# doesn't magically start at the bottom of the terminal
+prompt-at-bottom() {
+  printf '\n%.0s' {1..100}
 }
 
 # this will show all Powerlevel10K prompt elements


### PR DESCRIPTION
- Added a number of new aliases for git and apt, among others. Included a help message function that displays  (mainly to remind myself) some useful information, including useful aliases to remember.
- corrected ownall to be owndir in the helpmessage, as there is no ownall alias (yet /wink)
- Added function to cause zsh prompt to start at the bottom, eventually will only have this function run when transient prompt is enabled
