### PR TITLE
dev

### DIFF
--- a/.zprofile
+++ b/.zprofile
@@ -5,3 +5,8 @@
 # shells invoked with the -l flag.)
 #
 # Global Order: zshenv, zprofile, zshrc, zlogin
+if [[ -d /home/linuxbrew ]]; then
+    export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+    export MANPATH="/home/linuxbrew/.linuxbrew/share/man:$MANPATH"
+    export INFOPATH="/home/linuxbrew/.linuxbrew/share/info:$INFOPATH"
+fi

--- a/.zshenv
+++ b/.zshenv
@@ -16,7 +16,7 @@ fi
 # export PATH=~/bin:/sbin:/usr/local/bin:usr/share:$PATH
 
 # Linuxbrew stuff
-if command -v brew >/dev/null 2>&1; then
+if [[ -d /home/linuxbrew ]]; then
 	eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
 	# For compilers to find isl@0.18 you may need to set:
 	export LDFLAGS="-L/home/linuxbrew/.linuxbrew/opt/isl@0.18/lib"

--- a/.zshenv
+++ b/.zshenv
@@ -24,7 +24,3 @@ if command -v brew >/dev/null 2>&1; then
 	# For pkg-config to find isl@0.18 you may need to set:
 	export PKG_CONFIG_PATH="/home/linuxbrew/.linuxbrew/opt/isl@0.18/lib/pkgconfig"
 fi
-
-if [ ! -n "$ZDOTDIR" ] && [ -d /home/doc/.config/zsh ]; then
-    export ZDOTDIR=/home/doc/.config/zsh
-fi

--- a/.zshenv
+++ b/.zshenv
@@ -6,31 +6,25 @@
 # custom environment in such cases.  Note also that .zshenv should not contain
 # commands that produce output or assume the shell is attached to a tty.
 
-# If ZDOTDIR isn't already set in /etc/zsh/zshenv
-if [ ! -v ZDOTDIR ] && [ -d ~/.config/zsh ]; then
-	export ZDOTDIR=~/.config/zsh
-fi
-
-# ensure ZSH isn't set already and ensure .oh-my-zsh directory is present
-if [[ ! -v ZSH && -d $ZDOTDIR/.oh-my-zsh ]]; then # if oh-my-zsh is in $ZDOTDIR directory
-	export ZSH=$ZDOTDIR/.oh-my-zsh
-elif [[ ! -v ZSH && -d $HOME/.oh-my-zsh ]]; then # if oh-my-zsh is in $HOME directory
-    export ZSH=$HOME/.oh-my-zsh
+# Preferred editor for local and remote sessions
+if [[ -n $SSH_CONNECTION ]]; then
+   export EDITOR='vim'
+else
+   export EDITOR='gedit'
 fi
 
 # export PATH=~/bin:/sbin:/usr/local/bin:usr/share:$PATH
 
 # Linuxbrew stuff
-eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
-# For compilers to find isl@0.18 you may need to set:
-export LDFLAGS="-L/home/linuxbrew/.linuxbrew/opt/isl@0.18/lib"
-export CPPFLAGS="-I/home/linuxbrew/.linuxbrew/opt/isl@0.18/include"
-# For pkg-config to find isl@0.18 you may need to set:
-export PKG_CONFIG_PATH="/home/linuxbrew/.linuxbrew/opt/isl@0.18/lib/pkgconfig"
+if command -v brew >/dev/null 2>&1; then
+	eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
+	# For compilers to find isl@0.18 you may need to set:
+	export LDFLAGS="-L/home/linuxbrew/.linuxbrew/opt/isl@0.18/lib"
+	export CPPFLAGS="-I/home/linuxbrew/.linuxbrew/opt/isl@0.18/include"
+	# For pkg-config to find isl@0.18 you may need to set:
+	export PKG_CONFIG_PATH="/home/linuxbrew/.linuxbrew/opt/isl@0.18/lib/pkgconfig"
+fi
 
-# Preferred editor for local and remote sessions
- if [[ -n $SSH_CONNECTION ]]; then
-   export EDITOR='vim'
- else
-   export EDITOR='gedit'
- fi
+if [ ! -n "$ZDOTDIR" ] && [ -d /home/doc/.config/zsh ]; then
+    export ZDOTDIR=/home/doc/.config/zsh
+fi

--- a/.zshrc
+++ b/.zshrc
@@ -1,15 +1,16 @@
 # $ZDOTDIR/.zshrc
 
-# If not running as interactive prompt, do nothing.
-case $- in
-	*i*) ;;
-	*) return;;
-esac
-
 # P10K instant prompt. Keep close to top of .zshrc. Code that may require console input
 # password prompts, etc. must go above this block; everything else may go below.
 if [[ -r "${XDG_CACHE_HOME:-~/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
 	source "${XDG_CACHE_HOME:-~/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
+fi
+
+# if there's a $ZDOTDIR directory, oh-my-zsh is probably in it
+if [[ -n "$ZDOTDIR" ]]; then
+	export ZSH=$ZDOTDIR/.oh-my-zsh
+else # oh-my-zsh is probably in home directory
+    export ZSH=$HOME/.oh-my-zsh
 fi
 
 ZSH_THEME="powerlevel10k/powerlevel10k"

--- a/install.sh
+++ b/install.sh
@@ -354,13 +354,13 @@ while true; do
             printf "\nCreated symbolic link in home directory:\n"
             ln -sv $INSTALL_DIRECTORY/.zshenv $HOME/.zshenv
             printf "Inserting lines to export ZDOTDIR into .zshenv file...\n"
-            echo $INSERT_TEXT >> $HOME/.zshenv
+            echo -e $INSERT_TEXT >> $HOME/.zshenv
             printf "Operation complete: zsh will look for .zshenv in user's home directory and ZDOTDIR will be set by it" && sleep 1
             break
             ;;
         [2] )
             INSERT_TEXT="\n[[ -d $INSTALL_DIRECTORY && -f $INSTALL_DIRECTORY/.zshrc ]] && export ZDOTDIR=$INSTALL_DIRECTORY"
-            echo $INSERT_TEXT | sudo tee -a /etc/zsh/zshenv > /dev/null
+            echo -e $INSERT_TEXT | sudo tee -a /etc/zsh/zshenv > /dev/null
             printf "/etc/zsh/zshenv will now set and export the ZDOTDIR variable.\n"
             printf "!!!IMPORTANT: YOU NEED TO MODIFY THIS FILE IF YOU CHANGE YOUR ZDOTDIR DIRECTORY LOCATION!!!\n" && sleep 1
             break

--- a/install.sh
+++ b/install.sh
@@ -1,52 +1,34 @@
-#!/bin/sh
+#!/bin/bash
 
 # check if necessary packages are installed
-if command -v zsh &> /dev/null && command -v git &> /dev/null && command -v wget && command -v neofetch &> /dev/null; then
+if command -v zsh &> /dev/null && command -v git &> /dev/null && command -v wget && command -v neofetch &> /dev/null; 
+then
     printf "Zsh, Git, wget and neofetch are already installed\n"
 else
-    if sudo apt install -y zsh git wget || sudo pacman -S zsh git wget || sudo dnf install -y zsh git wget || sudo yum install -y zsh git wget || sudo brew install git zsh wget || pkg install git zsh wget ; then
+    if sudo apt install -y zsh git wget neofetch || sudo pacman -S zsh git wget neofetch || sudo dnf install -y zsh git wget neofetch || sudo yum install -y zsh git wget neofetch || pkg install git zsh wget neofetch;
+    then
         printf "Zsh, Git, wget and neofetch installed.\n"
     else
         printf "Please install the following packages first, then try again: zsh git wget neofetch\n" && exit
     fi
 fi
 
-INSTALL_DIRECTORY=$HOME/.config/zsh
 CLONED_REPO=$(pwd)
 
-# check if cloned repo is in home directory, if not ask to move it to home directory
-if [ -d "$HOME/Dotfiles" ]; then
-    printf "Dotfiles repo is located within users home directory.\nContinuing...\n"
-else
-    printf "Dotfiles repo is NOT located with users home directory.\n"
-    while true; do
-        read -p "Would you like to move the repo to your home directory? [Y/n]" yn
-        case  $yn in
-            [Yy]* )
-                printf "Moving repo to home directory..."
-                mv $CLONED_REPO $HOME/Dotfiles
-                cd $HOME/Dotfiles && CLONED_REPO=$(pwd)
-                break
-                ;;
-            [Nn]* )
-                printf "If an error occurs, you may want to try again after moving the repo to your home directory."
-                sleep 1
-                break
-                ;;
-            * )
-                printf "Please provide a valid answer."
-                ;;
-        esac
-    done
+# move cloned repo to home directory if not already there
+if [[ ! -d $HOME/Dotfiles ]]; then
+printf "Moving cloned Dotfiles repo directory to user's home directory.\n"
+    cd $HOME && mv $CLONED_REPO $HOME/Dotfiles
+    cd $HOME/Dotfiles && CLONED_REPO=$(pwd)
 fi
 
-
 # HOMEBREW/LINUXBREW INSTALL
-if [ -d /home/linuxbrew ]; then
+if command -v brew &> /dev/null; then
     printf "Homebrew is already installed.\n"
 else
     printf "Homebrew not installed.\n" 
     while true; do
+        printf "------------------------------------\n"
         read -p "Do you want to install Homebrew? [Y/n]:" yn
         case $yn in
             [Yy]* )
@@ -65,79 +47,98 @@ else
     done
 fi
 
-
 # MINICONDA INSTALL
 if [ -d $HOME/miniconda3 ]; then
-    printf "\nMiniconda3 is already installed.\n"
+    printf "Miniconda3 is already installed.\n"
 else
-    printf "\nMiniconda3 is not installed.\n"
+    printf "Miniconda3 is not installed.\n"
     while true; do
-        read -p "\nDo you want to install Miniconda? [Y/n]:" yn
+        printf "----------------------------------------\n"
+        read -p "Do you want to install Miniconda? [Y/n]:" yn
         case $yn in
             [Yy]* )
-                printf "Please be sure to install Miniconda3 to your users home directory.\n"
+                printf "Be sure to install Miniconda3 within your user's home directory.\n"
                 if [ -f $HOME/Miniconda3-latest-Linux-x86_64.sh ]; then # to prevent downloading Miniconda3 setup file multiple times
-                    printf "Miniconda3 is already downloaded\nStarting Miniconda3 setup...\n"
+                    printf "Miniconda3 is already downloaded\n"
+                    printf "Starting Miniconda3 setup...\n"
                     bash $HOME/Miniconda3-latest-Linux-x86_64.sh
                 else
                     printf "Downloading Miniconda3..."
                     wget -q --show-progress https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -P $HOME/
-                    printf "Download finished.\nStarting Miniconda3 setup...\n"
+                    printf "Download finished.\n"
+                    printf "Starting Miniconda3 setup...\n"
                     bash $HOME/Miniconda3-latest-Linux-x86_64.sh
                 fi
                 break
                 ;;
             [Nn]* )
-                printf "Answer: No.\nContinuing...\n"
+                printf "Answer: No.\n"
+                printf "Continuing...\n" && sleep 1
                 break
                 ;;
             * )
-                printf "\nPlease provide a valid answer.\n"
+                printf "Please provide a valid answer.\n"
                 ;;
         esac
     done
 fi
 
-# MINICONDA INSTALL CLEANUP
-if [ -f $HOME/Miniconda3-latest-Linux-x86_64.sh ] && [ -d $HOME/miniconda3 ]; then
-    printf "\nRemoving Miniconda3 install file...\n"
-    rm -f $HOME/Miniconda3-latest-Linux*
+# INSTALL CLEANUP
+if [ -f ~/Miniconda3-latest-* ] && [ -d ~/miniconda3 ]; then
+    printf "Removing Miniconda3 install file...\n"
+    ls -l ~/Miniconda3-latest-*
+    rm -f ~/Miniconda3-latest-*
 fi
 
-
-# Ask if user is ready to continue to Zsh configuration
+# ASK TO BACKUP FILES --- ZSH CONFIG INSTALLS BEGIN AFTER THIS
 while true; do
-    printf "\nAbout to start Zsh configuration.\nOh-My-Zsh, nerd fonts, OMZ plugins and Powerlevel10K theme will be installed.\n"
-    read -p "Continue? [Y/n]:" yn
+    printf "Are there dotfiles in your home directory that you want to backup?\n"
+    read -p "Backup existing dotfiles in home directory? [Y/n]:" yn
     case $yn in
         [Yy]* )
-            printf "\nContinuing install...\n"
-            if [ -f $HOME/.zshrc ]; then # backup .zshrc
-                mv $HOME/.zshrc $HOME/.zshrc-backup-$(date +"%Y-%m-%d")
-                printf "\nBacked up current .zshrc to .zshrc-backup-$(date +"%Y-%m-%d")\n"
+            printf "Starting backup...\n"
+            mkdir -p $HOME/Backup_Dotfiles # Create file backup directory
+            if [ -f $HOME/.zprofile ]; then
+                printf "Found .zprofile, backing up file to $HOME/Backup_Dotfiles...\n"
+                mv $HOME/.zprofile $HOME/Backup_Dotfiles/.zprofile-backup-$(date +"%Y-%m-%d")
+                printf "Backed up current .zprofile to .zprofile-backup-$(date +"%Y-%m-%d")\n"
             fi
-            sleep 1
+            if [ -f $HOME/.zshenv ]; then
+                printf "Found .zshenv, backing up file to $HOME/Backup_Dotfiles...\n"
+                mv $HOME/.zshenv $HOME/Backup_Dotfiles/.zshenv-backup-$(date +"%Y-%m-%d")
+                printf "Backed up current .zshenv to .zshenv-backup-$(date +"%Y-%m-%d")\n"
+            fi
+            if [ -f $HOME/.zshrc ]; then # backup .zshrc
+                printf "Found .zshrc, backing up file to $HOME/Backup_Dotfiles...\n"
+                mv $HOME/.zshrc $HOME/Backup_Dotfiles/.zshrc-backup-$(date +"%Y-%m-%d")
+                printf "Backed up current .zshrc to .zshrc-backup-$(date +"%Y-%m-%d")\n"
+            fi
+            printf "Finished backing up any existing zsh files. Continuing...\n" && sleep 1
             break
             ;;
         [Nn]* )
-            printf "\nStopping install...\n" && exit;
+            printf "Will continue without trying to backup existing files. Continuing...\n" && sleep 1
             break
             ;;
         * )
-            printf "\nPlease provide a valid answer.\n"
+            printf "Please provide a valid answer.\n"
             ;;
     esac
 done
 
+
 # CHOOSE INSTALL DIRECTORY
 while true; do
-    if [ ! -e "$INSTALL_DIRECTORY" ]; then
-        printf "\nDefault install directory is:\n$INSTALL_DIRECTORY\n"
+    if [[ ! -e "$INSTALL_DIRECTORY" ]]; then
+        printf "-------------------------------------------------\n"
+        printf "Where should your zsh and oh-my-zsh configuration files be installed?\n"
+        printf "!!!(FYI - the location should be in your user's home directory)\n"
+        printf "-------------------------------------------------\n"
+        printf "Default install directory is: $INSTALL_DIRECTORY\n"
         printf "  - Press ENTER to confirm the location\n"
         printf "  - Press CTRL-C to abort the installation\n"
         printf "  - Or specify a different location below\n"
         printf "[%s] >>> " "$INSTALL_DIRECTORY"
-
         read -r user_prefix
         if [ "$user_prefix" != "" ]; then
             case "$user_prefix" in
@@ -153,84 +154,119 @@ while true; do
         # check if user entry contained spaces
         case "$INSTALL_DIRECTORY" in
             *\ * )
-                printf "\nERROR: Cannot install into directories with spaces\n" >&2
+                printf "!!!\n"
+                printf "ERROR: Cannot install into directories with spaces\n" >&2
                 continue
                 ;;
         esac
         # if directory exists, don't try creating it
         if [ -e "$INSTALL_DIRECTORY" ]; then
-            printf "\nDirectory already exists, no need to create it.\n"
+            printf "\n"
+            printf "Directory already exists, no need to create it.\n"
             break
         else
             if mkdir -p "$INSTALL_DIRECTORY" 2>/dev/null; then
-                printf "\nDirectory created.\n" && ls -ld "$INSTALL_DIRECTORY"
+                printf "\n"
+                printf "Directory created.\n" && ls -ld "$INSTALL_DIRECTORY" && sleep 1
                 break
             else # let user know we couldn't create directory
-                printf "\nCouldn't create directory: $INSTALL_DIRECTORY\nMake sure you have the correct permissions to create the directory.\n"
-                sleep 1
+                printf "!!!\n"
+                printf "Couldn't create directory: $INSTALL_DIRECTORY \n"
+                printf "Make sure you have the correct permissions to create the directory.\n" && sleep 1
                 INSTALL_DIRECTORY=$HOME/.config/zsh
                 continue
             fi
         fi
     else
-        printf "\n$INSTALL_DIRECTORY already exists. No need to create it.\nContinuing...\n"
+        printf "\n"
+        printf "$INSTALL_DIRECTORY already exists. No need to create it.\n"
+        printf "Continuing...\n"
         break
     fi
 done
 
+
 # OMZ INSTALL
-printf "\nInstalling oh-my-zsh\n"
-if [ -d $HOME/.oh-my-zsh ]; then
-    printf "\noh-my-zsh is already installed in home directory, moving to new $HOME/.config/zsh directory...\n"
+printf "----------------------"
+printf "Installing oh-my-zsh\n" && sleep 1
+export ZSH=$INSTALL_DIRECTORY/.oh-my-zsh
+if [ -d $HOME/.oh-my-zsh ]; then # OMZ already installed, but located in user's home dir
+    printf "oh-my-zsh is already installed in home directory, moving to new $INSTALL_DIRECTORY directory...\n"
     mv $HOME/.oh-my-zsh $INSTALL_DIRECTORY
     cd $INSTALL_DIRECTORY/.oh-my-zsh && git pull
 else
-    ZSH=$INSTALL_DIRECTORY/.oh-my-zsh
-    if [ -d $INSTALL_DIRECTORY/.oh-my-zsh ]; then
-        printf "\noh-my-zsh is already installed in $INSTALL_DIRECTORY.\n"
+    if [ -d $INSTALL_DIRECTORY/.oh-my-zsh ]; then # OMZ installed in install dir
+        printf "oh-my-zsh is already installed in $INSTALL_DIRECTORY.\n"
         cd $INSTALL_DIRECTORY/.oh-my-zsh && git pull
     else
-        printf "\noh-my-zsh is not installed. Installing...\n"
+        printf "oh-my-zsh is not installed. Installing...\n" # OMZ not installed
         sh -c "$(wget https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh -O -)" "" --unattended
     fi
 fi
 
-# OMZ PLUGINS
-if [ -d $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-autosuggestions ]; then
-    cd $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-autosuggestions && git pull
+printf "Ready to install OMZ plugins...\n" && sleep 1
+
+
+if [ -d $INSTALL_DIRECTORY/.oh-my-zsh ]; then
+    # OMZ PLUGINS
+    if [ -d $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-autosuggestions ]; then
+        cd $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-autosuggestions && git pull
+    else
+        git clone --depth=1 https://github.com/zsh-users/zsh-autosuggestions.git $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-autosuggestions
+    fi
+
+    if [ -d $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/conda-zsh-completion ]; then
+        cd $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/conda-zsh-completion && git pull
+    else
+        git clone --depth=1 https://github.com/esc/conda-zsh-completion.git $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/conda-zsh-completion
+    fi
+
+    if [ -d $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting ]; then
+        cd $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting && git pull
+    else
+        git clone --depth=1 https://github.com/zsh-users/zsh-syntax-highlighting.git $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting
+    fi
+
+    if [ -d $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-autocompletion ]; then
+        cd $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-autocompletion && git pull
+    else
+        git clone --depth=1 https://github.com/marlonrichert/zsh-autocomplete.git $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-autocomplete
+    fi
+
+    if [ -d $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-history-substring-search ]; then
+        cd $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-history-substring-search && git pull
+    else
+        git clone --depth=1 https://github.com/zsh-users/zsh-history-substring-search.git $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-history-substring-search
+    fi
+    # POWERLEVEL10K THEME
+    if [ -d $INSTALL_DIRECTORY/.oh-my-zsh/custom/themes/powerlevel10k ]; then
+        cd $INSTALL_DIRECTORY/.oh-my-zsh/custom/themes/powerlevel10k && git pull
+    else
+        git clone --depth=1 https://github.com/romkatv/powerlevel10k.git $INSTALL_DIRECTORY/.oh-my-zsh/custom/themes/powerlevel10k
+    fi
 else
-    git clone --depth=1 https://github.com/zsh-users/zsh-autosuggestions.git $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-autosuggestions
+    printf "Something's wrong, oh-my-zsh isn't in $INSTALL_DIRECTORY...\n"
+    printf "Checking if oh-my-zsh is in home directory...\n" && sleep 1
+    if [ -d ~/.oh-my-zsh ]; then
+        printf "oh-my-zsh is in home directory, will move it to $INSTALL_DIRECTORY...\n"
+        mv ~/.oh-my-zsh $INSTALL_DIRECTORY && printf "oh-my-zsh directory moved to $INSTALL_DIRECTORY, can proceed now\n" && sleep 1
+    else
+        printf "oh-my-zsh is NOT in home directory, something is wrong\n"
+        printf "Exitting before attempting anything further\n" && sleep 1
+        exit
+    fi
 fi
 
-if [ -d $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/conda-zsh-completion ]; then
-    cd $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/conda-zsh-completion && git pull
+# INSTALL EMOJI FONTS IF NONE FOUND
+if fc-list | grep -i emoji >/dev/null; then
+    printf "Emoji fonts found, won't install any more. If emojis are missing try downloading fonts-noto-color-emoji and fonts-recommended packages\n"
 else
-    git clone --depth=1 https://github.com/esc/conda-zsh-completion.git $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/conda-zsh-completion
-fi
-
-if [ -d $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting ]; then
-    cd $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting && git pull
-else
-    git clone --depth=1 https://github.com/zsh-users/zsh-syntax-highlighting.git $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting
-fi
-
-if [ -d $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-autocompletion ]; then
-    cd $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-autocompletion && git pull
-else
-    git clone --depth=1 https://github.com/marlonrichert/zsh-autocomplete.git $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-autocomplete
-fi
-
-if [ -d $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-history-substring-search ]; then
-    cd $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-history-substring-search && git pull
-else
-    git clone --depth=1 https://github.com/zsh-users/zsh-history-substring-search.git $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins/zsh-history-substring-search
-fi
-
-# POWERLEVEL10K THEME
-if [ -d $INSTALL_DIRECTORY/.oh-my-zsh/custom/themes/powerlevel10k ]; then
-    cd $INSTALL_DIRECTORY/.oh-my-zsh/custom/themes/powerlevel10k && git pull
-else
-    git clone --depth=1 https://github.com/romkatv/powerlevel10k.git $INSTALL_DIRECTORY/.oh-my-zsh/custom/themes/powerlevel10k
+    if sudo apt install -y fonts-noto-color-emoji fonts-recommended || sudo pacman -S fonts-noto-color-emoji fonts-recommended || sudo dnf install -y fonts-noto-color-emoji fonts-recommended || sudo yum install -y fonts-noto-color-emoji fonts-recommended || pkg install fonts-noto-color-emoji fonts-recommended;
+    then
+        printf "Fonts to show latest emojis are installed\n"
+    else
+        printf "Couldn't install fonts, latest emojis may not show correctly\n"
+    fi
 fi
 
 # INSTALL NERD FONTS
@@ -260,7 +296,6 @@ while true; do
             else
                 printf "Installing Roboto Mono Nerd Font Complete...\n"
                 wget -q --show-progress -N https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/RobotoMono/Regular/complete/Roboto%20Mono%20Nerd%20Font%20Complete.ttf -P $HOME/.fonts/
-            
             fi
             # Hack Regular Nerd Font
             if [ -f $HOME/.fonts/Hack\ Regular\ Nerd\ Font\ Complete.ttf ]; then
@@ -290,54 +325,14 @@ while true; do
     esac
 done
 
-# cd $HOME
-
-# ASK TO BACKUP FILES
-while true; do
-    printf "\nAre there dotfiles in your home directory that you want to backup?\n"
-    read -p "Backup existing dotfiles in home directory? [Y/n]:" yn
-    case $yn in
-        [Yy]* )
-            printf "\nStarting backup...\n"
-            mkdir -p $HOME/Backup_Dotfiles # Create file backup directory
-                if [ -f $HOME/.p10k.zsh ]; then # Move all related dotfiles (if they exist) to Backup_Dotfiles directory
-                printf "Found .p10k.zsh, moving file to $HOME/Backup_Dotfiles...\n"
-                mv $HOME/.p10k.zsh $HOME/Backup_Dotfiles
-            fi
-            if [ -f $HOME/.zprofile ]; then
-                printf "Found .zprofile, moving file to $HOME/Backup_Dotfiles...\n"
-                mv $HOME/.zprofile $HOME/Backup_Dotfiles
-            fi
-            if [ -f $HOME/.zshenv ]; then
-                printf "Found .zshenv, moving file to $HOME/Backup_Dotfiles...\n"
-                mv $HOME/.zshenv $HOME/Backup_Dotfiles/.zshenv-backup-$(date +"%Y-%m-%d")
-            fi
-            if [ -f $HOME/.zshrc ]; then
-                printf "Found .zshrc, moving file to $HOME/Backup_Dotfiles...\n"
-                mv $HOME/.zshrc* $HOME/Backup_Dotfiles
-            fi
-            printf "Finished backing up any existing files. Continuing..."
-            break
-            ;;
-        [Nn]* )
-            printf "\nWill continue without trying to backup existing files. Continuing...\n"
-            break
-            ;;
-        * )
-            printf "\nPlease provide a valid answer.\n"
-            ;;
-    esac
-done
-
-
-
 # COPY FILES FROM REPO
 # the two .zsh files in omz-files need to go in .oh-my-zsh/custom/
 cd $CLONED_REPO/omz-files
 for i in *; do
     if [ -f $i ]; then
         if [ "$i" = "_better-help" ]; then
-            [[ ! -d $INSTALL_DIRECTORY/.oh-my-zsh/completions ]] && mkdir -p $INSTALL_DIRECTORY/.oh-my-zsh/completions # in case completioons dir isn't there
+            [[ ! -d $INSTALL_DIRECTORY/.oh-my-zsh/completions ]] &&
+            mkdir $INSTALL_DIRECTORY/.oh-my-zsh/completions && # in case completions dir isn't there
             cp $i $INSTALL_DIRECTORY/.oh-my-zsh/completions
         else
             cp -f $i $INSTALL_DIRECTORY/.oh-my-zsh/custom
@@ -348,7 +343,7 @@ for i in *; do
 done
 
 # directory for storing Powerlevel10K themes
-if [ ! -d $INSTALL_DIRECTORY/P10K-themes ]; then
+if [[ ! -d $INSTALL_DIRECTORY/P10K-themes ]]; then
     mkdir -p $INSTALL_DIRECTORY/P10K-themes
 fi
 
@@ -378,27 +373,27 @@ while true; do
     printf "\nTo set the ZDOTDIR variable required to let Zsh know where to look for the .zsh files, we can either symlink the .zshenv file with the export ZDOTDIR line in it from your install directory, or we can export the variable in /etc/zsh/zshenv.\n"
     printf "If you'd prefer to set it some other way, choose option 3.\n"
     printf "\nHOW SHOULD ZDOTDIR BE SET?\n"
-    printf "[1]     Create symbolic link to $INSTALL_DIRECTORY/.zshenv in $HOME directory\n"
+    printf "[1]     Create symbolic link to $INSTALL_DIRECTORY/.zshenv in $HOME directory and append lines exporting ZDOTDIR to it\n"
     printf "[2]     Use /etc/zsh/zshenv file to set ZDOTDIR to $INSTALL_DIRECTORY (may require sudo priviledges)\n"
     printf "[3]     Do nothing; ZDOTDIR is already set, or I am going to set the ZDOTDIR variable myself.\n"
     printf ">>> "
     read -r choice
     case $choice in
         [1] )
-            printf "\nCreated symbolic link:\n"
+            printf "\nCreated symbolic link in home directory:\n"
             ln -sv $INSTALL_DIRECTORY/.zshenv $HOME/.zshenv
+            printf "Inserting lines to export ZDOTDIR into .zshenv file...\n"
+            echo "\nif [[ ! -n \"\$ZDOTDIR\" ]] && [ -d $INSTALL_DIRECTORY ]; then\n    export ZDOTDIR=$INSTALL_DIRECTORY\nfi" >> $HOME/.zshenv
             sleep 1
             break
             ;;
         [2] )
-            echo -e "[[ -d $INSTALL_DIRECTORY && -f $INSTALL_DIRECTORY/.zshrc ]] && export ZDOTDIR=$INSTALL_DIRECTORY" | sudo tee -a /etc/zsh/zshenv > /dev/null
-            printf "\n/etc/zsh/zshenv will now set the ZDOTDIR variable. Be sure to modify this file if you wish to change the location of your zsh dotfiles directory.\n"
-            sleep 1
+            echo "\n[[ -d $INSTALL_DIRECTORY && -f $INSTALL_DIRECTORY/.zshrc ]] && export ZDOTDIR=$INSTALL_DIRECTORY" | sudo tee -a /etc/zsh/zshenv > /dev/null
+            printf "/etc/zsh/zshenv will now set and export the ZDOTDIR variable. Be sure to modify this file if you wish to change the location of your zsh dotfiles directory.\n" && sleep 1
             break
             ;;
         [3] )
-            printf "\nNothing will be done. Continuing on to final steps...\n"
-            sleep 1
+            printf "\nNothing will be done. Continuing on to final steps...\n" && sleep 1
             break
             ;;
         * )
@@ -410,17 +405,17 @@ done
 export ZDOTDIR=$INSTALL_DIRECTORY
 
 # Change shell to zsh and run omz update
-printf "\nSudo access is needed to change default shell\n"
+printf "Sudo access is needed to change default shell\n"
 if chsh -s $(which zsh); then
     if /bin/zsh -i -c 'omz update'; then
-        printf "\nInstallation Successful, exit terminal and enter a new session\n"
+        printf "Installation Successful, exit terminal and enter a new session\n"
     elif /bin/zsh -i -c upgrade_oh_my_zsh; then # in case omz update fails, will fallback to using upgrade_oh_my_zsh to finish install
-        printf "\nInstallation Successful, exit terminal and enter a new session\n"
+        printf "Installation Successful, exit terminal and enter a new session\n"
     else
-        printf "\nSomething went wrong\n"
+        printf "Something went wrong\n"
     fi
 else
-    printf "\nSomething went wrong\n"
+    printf "Something went wrong\n"
 fi
 
 exit

--- a/install.sh
+++ b/install.sh
@@ -28,7 +28,6 @@ if command -v brew &> /dev/null; then
 else
     printf "Homebrew not installed.\n" 
     while true; do
-        printf "------------------------------------\n"
         read -p "Do you want to install Homebrew? [Y/n]:" yn
         case $yn in
             [Yy]* )
@@ -53,7 +52,6 @@ if [ -d $HOME/miniconda3 ]; then
 else
     printf "Miniconda3 is not installed.\n"
     while true; do
-        printf "----------------------------------------\n"
         read -p "Do you want to install Miniconda? [Y/n]:" yn
         case $yn in
             [Yy]* )
@@ -130,10 +128,10 @@ done
 # CHOOSE INSTALL DIRECTORY
 while true; do
     if [[ ! -e "$INSTALL_DIRECTORY" ]]; then
-        printf "-------------------------------------------------\n"
+        printf "\n"
         printf "Where should your zsh and oh-my-zsh configuration files be installed?\n"
         printf "!!!(FYI - the location should be in your user's home directory)\n"
-        printf "-------------------------------------------------\n"
+        printf "\n"
         printf "Default install directory is: $INSTALL_DIRECTORY\n"
         printf "  - Press ENTER to confirm the location\n"
         printf "  - Press CTRL-C to abort the installation\n"
@@ -187,7 +185,7 @@ done
 
 
 # OMZ INSTALL
-printf "----------------------"
+printf "\n"
 printf "Installing oh-my-zsh\n" && sleep 1
 export ZSH=$INSTALL_DIRECTORY/.oh-my-zsh
 if [ -d $HOME/.oh-my-zsh ]; then # OMZ already installed, but located in user's home dir

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
 # check if necessary packages are installed
-if command -v zsh &> /dev/null && command -v git &> /dev/null && command -v wget && command -v neofetch &> /dev/null; 
+if command -v zsh > /dev/null 2>&1 && command -v git > /dev/null 2>&1 && command -v wget > /dev/null 2>&1 && command -v neofetch > /dev/null 2>&1; 
 then
     printf "Zsh, Git, wget and neofetch are already installed\n"
 else
@@ -20,30 +20,6 @@ if [[ ! -d $HOME/Dotfiles ]]; then
 printf "Moving cloned Dotfiles repo directory to user's home directory.\n"
     cd $HOME && mv $CLONED_REPO $HOME/Dotfiles
     cd $HOME/Dotfiles && CLONED_REPO=$(pwd)
-fi
-
-# HOMEBREW/LINUXBREW INSTALL
-if command -v brew &> /dev/null; then
-    printf "Homebrew is already installed.\n"
-else
-    printf "Homebrew not installed.\n" 
-    while true; do
-        read -p "Do you want to install Homebrew? [Y/n]:" yn
-        case $yn in
-            [Yy]* )
-                printf "Installing Homebrew..."
-                /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-                break
-                ;;
-            [Nn]* )
-                printf "Homebrew will not be installed.\nContinuing..."
-                break
-                ;;
-            * )
-                printf "Please provide a valid answer."
-                ;;
-        esac
-    done
 fi
 
 # MINICONDA INSTALL
@@ -127,59 +103,54 @@ done
 
 # CHOOSE INSTALL DIRECTORY
 while true; do
-    if [[ ! -e "$INSTALL_DIRECTORY" ]]; then
-        printf "\n"
-        printf "Where should your zsh and oh-my-zsh configuration files be installed?\n"
-        printf "!!!(FYI - the location should be in your user's home directory)\n"
-        printf "\n"
-        printf "Default install directory is: $INSTALL_DIRECTORY\n"
-        printf "  - Press ENTER to confirm the location\n"
-        printf "  - Press CTRL-C to abort the installation\n"
-        printf "  - Or specify a different location below\n"
-        printf "[%s] >>> " "$INSTALL_DIRECTORY"
-        read -r user_prefix
-        if [ "$user_prefix" != "" ]; then
-            case "$user_prefix" in
-                *\ * )
-                    printf "ERROR: Cannot install into directories with spaces\n" >&2
-                    continue
-                    ;;
-                *)
-                    eval INSTALL_DIRECTORY="$user_prefix"
-                    ;;
-            esac
-        fi
-        # check if user entry contained spaces
-        case "$INSTALL_DIRECTORY" in
+    printf "\n"
+    printf "Where should your zsh and oh-my-zsh configuration files be installed?\n"
+    printf "!!!(FYI - the location should be in your user's home directory)\n\n"
+
+    INSTALL_DIRECTORY=$HOME/.config/zsh # Default installation directory
+    
+    printf "Default install directory is: $INSTALL_DIRECTORY\n"
+    printf "  - Press ENTER to confirm the location\n"
+    printf "  - Press CTRL-C to abort the installation\n"
+    printf "  - Or specify a different location below\n"
+    printf "[%s] >>> " "$INSTALL_DIRECTORY"
+    read -r user_prefix
+    if [ "$user_prefix" != "" ]; then
+        case "$user_prefix" in
             *\ * )
-                printf "!!!\n"
                 printf "ERROR: Cannot install into directories with spaces\n" >&2
                 continue
                 ;;
+            *)
+                eval INSTALL_DIRECTORY="$user_prefix"
+                ;;
         esac
-        # if directory exists, don't try creating it
-        if [ -e "$INSTALL_DIRECTORY" ]; then
-            printf "\n"
-            printf "Directory already exists, no need to create it.\n"
-            break
-        else
-            if mkdir -p "$INSTALL_DIRECTORY" 2>/dev/null; then
-                printf "\n"
-                printf "Directory created.\n" && ls -ld "$INSTALL_DIRECTORY" && sleep 1
-                break
-            else # let user know we couldn't create directory
-                printf "!!!\n"
-                printf "Couldn't create directory: $INSTALL_DIRECTORY \n"
-                printf "Make sure you have the correct permissions to create the directory.\n" && sleep 1
-                INSTALL_DIRECTORY=$HOME/.config/zsh
-                continue
-            fi
-        fi
-    else
+    fi
+    # check if user entry contained spaces
+    case "$INSTALL_DIRECTORY" in
+        *\ * )
+            printf "!!!\n"
+            printf "ERROR: Cannot install into directories with spaces\n" >&2
+            continue
+            ;;
+    esac
+    # if directory exists, don't try creating it
+    if [ -e "$INSTALL_DIRECTORY" ]; then
         printf "\n"
-        printf "$INSTALL_DIRECTORY already exists. No need to create it.\n"
-        printf "Continuing...\n"
+        printf "Directory already exists, no need to create it.\n"
         break
+    else
+        if mkdir -p "$INSTALL_DIRECTORY" 2>/dev/null; then
+            printf "\n"
+            printf "Directory created.\n" && ls -ld "$INSTALL_DIRECTORY" && sleep 1
+            break
+        else # let user know we couldn't create directory
+            printf "!!!\n"
+            printf "Couldn't create directory: $INSTALL_DIRECTORY \n"
+            printf "Make sure you have the correct permissions to create the directory.\n" && sleep 1
+            INSTALL_DIRECTORY=$HOME/.config/zsh
+            continue
+        fi
     fi
 done
 
@@ -368,9 +339,10 @@ printf "\nFinished setting up repo files in new $INSTALL_DIRECTORY directory.\n"
 cd $HOME
 
 while true; do
-    printf "\nTo set the ZDOTDIR variable required to let Zsh know where to look for the .zsh files, we can either symlink the .zshenv file with the export ZDOTDIR line in it from your install directory, or we can export the variable in /etc/zsh/zshenv.\n"
-    printf "If you'd prefer to set it some other way, choose option 3.\n"
-    printf "\nHOW SHOULD ZDOTDIR BE SET?\n"
+    INSTALL_DIRECTORY=$HOME/.config/zsh
+    printf "\nTo set the ZDOTDIR variable required to let Zsh know where to look for the .zsh files, we can either symlink the .zshenv file\nwith the export ZDOTDIR line in it from your install directory, or we can export the variable in /etc/zsh/zshenv.\n"
+    printf "\nIf you'd prefer to set it some other way, choose option 3.\n"
+    printf "\nOPTIONS:\n"
     printf "[1]     Create symbolic link to $INSTALL_DIRECTORY/.zshenv in $HOME directory and append lines exporting ZDOTDIR to it\n"
     printf "[2]     Use /etc/zsh/zshenv file to set ZDOTDIR to $INSTALL_DIRECTORY (may require sudo priviledges)\n"
     printf "[3]     Do nothing; ZDOTDIR is already set, or I am going to set the ZDOTDIR variable myself.\n"
@@ -378,16 +350,19 @@ while true; do
     read -r choice
     case $choice in
         [1] )
+            INSERT_TEXT="\n[[ ! -n \"\$ZDOTDIR\" && -d $INSTALL_DIRECTORY ]] && export ZDOTDIR=$INSTALL_DIRECTORY"
             printf "\nCreated symbolic link in home directory:\n"
             ln -sv $INSTALL_DIRECTORY/.zshenv $HOME/.zshenv
             printf "Inserting lines to export ZDOTDIR into .zshenv file...\n"
-            echo "\nif [[ ! -n \"\$ZDOTDIR\" ]] && [ -d $INSTALL_DIRECTORY ]; then\n    export ZDOTDIR=$INSTALL_DIRECTORY\nfi" >> $HOME/.zshenv
-            sleep 1
+            echo $INSERT_TEXT >> $HOME/.zshenv
+            printf "Operation complete: zsh will look for .zshenv in user's home directory and ZDOTDIR will be set by it" && sleep 1
             break
             ;;
         [2] )
-            echo "\n[[ -d $INSTALL_DIRECTORY && -f $INSTALL_DIRECTORY/.zshrc ]] && export ZDOTDIR=$INSTALL_DIRECTORY" | sudo tee -a /etc/zsh/zshenv > /dev/null
-            printf "/etc/zsh/zshenv will now set and export the ZDOTDIR variable. Be sure to modify this file if you wish to change the location of your zsh dotfiles directory.\n" && sleep 1
+            INSERT_TEXT="\n[[ -d $INSTALL_DIRECTORY && -f $INSTALL_DIRECTORY/.zshrc ]] && export ZDOTDIR=$INSTALL_DIRECTORY"
+            echo $INSERT_TEXT | sudo tee -a /etc/zsh/zshenv > /dev/null
+            printf "/etc/zsh/zshenv will now set and export the ZDOTDIR variable.\n"
+            printf "!!!IMPORTANT: YOU NEED TO MODIFY THIS FILE IF YOU CHANGE YOUR ZDOTDIR DIRECTORY LOCATION!!!\n" && sleep 1
             break
             ;;
         [3] )
@@ -404,14 +379,10 @@ export ZDOTDIR=$INSTALL_DIRECTORY
 
 # Change shell to zsh and run omz update
 printf "Sudo access is needed to change default shell\n"
-if chsh -s $(which zsh); then
-    if /bin/zsh -i -c 'omz update'; then
-        printf "Installation Successful, exit terminal and enter a new session\n"
-    elif /bin/zsh -i -c upgrade_oh_my_zsh; then # in case omz update fails, will fallback to using upgrade_oh_my_zsh to finish install
-        printf "Installation Successful, exit terminal and enter a new session\n"
-    else
-        printf "Something went wrong\n"
-    fi
+if chsh -s $(which zsh) && /bin/zsh -i -c 'omz update'; then
+    printf "Installation Successful, exit terminal and enter a new session\n"
+elif /bin/zsh -i -c upgrade_oh_my_zsh > /dev/null 2>&1; then # in case omz update fails, will fallback to using upgrade_oh_my_zsh to finish install
+    printf "Installation Successful, exit terminal and enter a new session\n"
 else
     printf "Something went wrong\n"
 fi

--- a/omz-files/doc_functions.zsh
+++ b/omz-files/doc_functions.zsh
@@ -40,6 +40,24 @@ BIPurple='\033[1;95m'     # Purple
 BICyan='\033[1;96m'       # Cyan
 BIWhite='\033[1;97m'      # White
 
+# displays helpful info if $HELP_MSG is true
+info-message() {
+  echo $BRed'       USEFUL COMMANDS'
+  echo $IWhite'-------------------------------'
+  echo $BIBlue'Use `sys-update` to update & upgrade Parrot, `sys-info` will dispay information about your system (and this message). You can use `s` and `e` for `sudo` and `echo`, respectively.'
+  echo 'Use `own` to take ownership of files. Use `owndir` to recursively take ownership of directories.'
+  echo 'Use `z` to change to $ZDOTDIR. Use cheat to lookup cheatsheets if needing help.'
+  echo $IWhite'-------------------------------'
+  echo $BIGreen'GENERAL(Aliases listed here have -ffs alias versions which use sudo): `cpd` (`cp -r`) | `symlinkmk` (`ln -srv`)'
+  echo 'APT/DPKG(no need to use sudo with these):\n`clean`=apt-get autoremove with --purge and apt-get autoclean | `afix`=apt-get install -f'
+  echo '`a`=apt | `ag`=apt-get | `ac`=apt-cache | `fix`=apt-get install -f'
+  echo '`au`=update || `ai`=install || `ar`=reinstall || `arm`=remove || `ap`=purge || `af`=search || `ash`=show'
+  echo '`mark-auto`=apt-mark auto | `mark-manual`=apt-mark manual | `reconfigure`= dpkg-reconfigure | `add-architecture`=dpkg --add-architecture'
+  echo $IWhite'-------------------------------'
+  echo $BICyan'GIT: `git-commit-push`=prompt for commit msg and push | `gsw`=switch branch | `gl`=pull | `gp`=push | `gstat`=status | `gstall`=commit all'
+  echo 'Keep in mind, `git-commit-push` prompts for a commit message and then immediately pushes all changes to the repo. So be mindful of what files it will be committing.\n'
+  echo $BRed'IF USING PARROT OS DO NOT USE APT UPGRADE! USE PARROT-UPGRADE INSTEAD, PARROT IS A ROLLING DISTRO AND USING APT UPGRADE CAN MESS THINGS UP!' $color_off
+}
 
 # Because getting told "there is no list of special help topoics available at this time." is just not helpful enough
 better-help() {
@@ -50,37 +68,18 @@ better-help() {
   fi
 }
 
-# displays helpful info if $HELP_MSG is true
-info-message() {
-    echo $BRed'       USEFUL COMMANDS'
-    echo $IWhite'-------------------------------'
-    echo $BIBlue'Use `sys-update` to update & upgrade Parrot, `sys-info` will dispay information about your system (and this message). You can use `s` and `e` for `sudo` and `echo`, respectively.'
-    echo 'Use `own` to take ownership of files. Use `owndir` to recursively take ownership of directories.'
-    echo 'Use `z` to change to $ZDOTDIR. Use cheat to lookup cheatsheets if needing help.'
-    echo $IWhite'-------------------------------'
-    echo $BIGreen'GENERAL(Aliases listed here have -ffs alias versions which use sudo): `cpd` (`cp -r`) | `symlinkmk` (`ln -srv`)'
-    echo 'APT/DPKG(no need to use sudo with these):\n`clean`=apt-get autoremove with --purge and apt-get autoclean | `afix`=apt-get install -f'
-    echo '`a`=apt | `ag`=apt-get | `ac`=apt-cache | `fix`=apt-get install -f'
-    echo '`au`=update || `ai`=install || `ar`=reinstall || `arm`=remove || `ap`=purge || `af`=search || `ash`=show'
-    echo '`mark-auto`=apt-mark auto | `mark-manual`=apt-mark manual | `reconfigure`= dpkg-reconfigure | `add-architecture`=dpkg --add-architecture'
-    echo $IWhite'-------------------------------'
-    echo $BICyan'GIT: `git-commit-push`=prompt for commit msg and push | `gsw`=switch branch | `gl`=pull | `gp`=push | `gstat`=status | `gstall`=commit all'
-	echo 'Keep in mind, `git-commit-push` prompts for a commit message and then immediately pushes all changes to the repo. So be mindful of what files it will be committing.\n'
-	echo $BRed'IF USING PARROT OS DO NOT USE APT UPGRADE! USE PARROT-UPGRADE INSTEAD, PARROT IS A ROLLING DISTRO AND USING APT UPGRADE CAN MESS THINGS UP!' $color_off
-}
-
 # This is because I'm using transient prompt and my prompt
 # doesn't magically start at the bottom of the terminal
 terminal-startup() {  
-	if [[ -o interactive ]]; then
-		printf '\n%.0s' {1..100}
-		if $STARTUP_CONTENT; then
-			neofetch
-			info-message
-		fi
-	elif [[ -o login ]]; then
-		info-message
-	fi
+  if [[ -o interactive ]]; then
+    printf '\n%.0s' {1..100}
+    if $STARTUP_CONTENT; then
+      neofetch
+      info-message
+    fi
+  elif [[ -o login ]]; then
+    info-message
+  fi
 }
 
 # this will show all Powerlevel10K prompt elements
@@ -90,39 +89,37 @@ p10k-prompt-info() {
 	printf '%-32s = %q\n' ${(@kv)reply} | sort
 }
 
-'''
 # function for committing changes and pushing to github automatically
-gc-push() {
-	if [[ $VCS_STATUS_HAS_UNSTAGED != 0 || $VCS_STATUS_HAS_UNTRACKED != 0 ]]; then
-		if git status; then
-			printf "Enter a commit message:\n"
-			vared -c commit_msg
-			if [ "$commit_msg" != "" ]; then
-				git commit -a -m "$commit_msg"
-				if git push; then
-					printf "Changes committed and pushed to the upstream branch successfully.\n"
-				else
-					printf "Something went wrong. Nothing pushed to upstream branch.\n"
-				fi
-			else
-				printf "Commit message cannot be nothing.\n"
-			fi
-			else
-				printf "Nothing to commit!\n"
-		fi
-	fi
-}
-'''
+#gc-push() {
+#	if [[ $VCS_STATUS_HAS_UNSTAGED != 0 || $VCS_STATUS_HAS_UNTRACKED != 0 ]]; then
+#		if git status; then
+#			printf "Enter a commit message:\n"
+#			vared -c commit_msg
+#			if [ "$commit_msg" != "" ]; then
+#				git commit -a -m "$commit_msg"
+#				if git push; then
+#					printf "Changes committed and pushed to the upstream branch successfully.\n"
+#				else
+#					printf "Something went wrong. Nothing pushed to upstream branch.\n"
+#				fi
+#			else
+#				printf "Commit message cannot be nothing.\n"
+#			fi
+#			else
+#				printf "Nothing to commit!\n"
+#		fi
+#	fi
+#}
 
 # edit recent git commit
 function git-commit-edit() {
 	git add .
-    if [ "$1" != "" ]; then
-        git commit -m "$1"
-    else
-        git commit -m update # default commit message is `update`
-    fi # closing statement of if-else block
-    git push origin HEAD
+  if [ "$1" != "" ]; then
+      git commit -m "$1"
+  else
+      git commit -m update # default commit message is `update`
+  fi # closing statement of if-else block
+  git push origin HEAD
 }
 
 # cheat sheets (github.com/chubin/cheat.sh), find out how to use commands


### PR DESCRIPTION
- update
- updated .zshenv
- more bug fixes in install.sh
- took out linuxbrew install option due to some changes with linuxbrew. install script should no longer be broken, and added checks for linuxbrew lines in .zshenv and .zprofile
- added -e option to echo so it would create a newline when inserting text in .zshenv or /etc/zsh/zshenv instead of literally adding \n at the beginning of the inserted text line. install.sh is working well again and finishing successfully (at least for parrot os)
