### PR TITLE
dev

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -64,10 +64,12 @@ if type brew &>/dev/null; then
 fi
 
 # GitHub CLI completions
-if [[ ! -d "$ZSH/completions" || ! -f "$ZSH/completions/_gh" ]]; then
-	mkdir -pv $ZSH/completions
-	gh completion --shell zsh > $ZSH/completions/_gh
-	echo "gh added completions: gh completion --shell zsh > $ZSH/completions/_gh"
+if command -v gh > /dev/null &>2; then
+	if [[ ! -d "$ZSH/completions" || ! -f "$ZSH/completions/_gh" ]]; then
+		mkdir -pv $ZSH/completions
+		gh completion --shell zsh > $ZSH/completions/_gh
+		echo "gh added completions: gh completion --shell zsh > $ZSH/completions/_gh"
+	fi
 fi
 
 # sourced files

--- a/install.sh
+++ b/install.sh
@@ -307,7 +307,7 @@ for i in *; do
     # if miniconda is installed, need to copy conda_setup.zsh as well
     [[ "$i" = "conda_setup.zsh" && -f $HOME/miniconda3/condabin/conda ]] && cp -uv $i $INSTALL_DIRECTORY/.oh-my-zsh/custom
     # symlink alias and function files (they both begin with "doc_") so they can easily be modified from omz-files directory
-    [[ "$i" = "doc_"* ]] && ln -sv $i $INSTALL_DIRECTORY/.oh-my-zsh/custom
+    [[ "$i" = "doc_"* ]] && ln -sv $(pwd)/$i $INSTALL_DIRECTORY/.oh-my-zsh/custom
     # copy nordvpn plugin to custom plugins directory (nordvpn plugin is yet to be included in oh-my-zsh outside of it's testing branch)
     [[ -d $i ]] && cp -ru $i $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins
 done && sleep 1

--- a/install.sh
+++ b/install.sh
@@ -354,13 +354,13 @@ while true; do
             printf "\nCreated symbolic link in home directory:\n"
             ln -sv $INSTALL_DIRECTORY/.zshenv $HOME/.zshenv
             printf "Inserting lines to export ZDOTDIR into .zshenv file...\n"
-            echo -e $INSERT_TEXT >> $HOME/.zshenv
+            echo -e "$INSERT_TEXT" | tee -a $HOME/.zshenv > /dev/null
             printf "Operation complete: zsh will look for .zshenv in user's home directory and ZDOTDIR will be set by it" && sleep 1
             break
             ;;
         [2] )
             INSERT_TEXT="\n[[ -d $INSTALL_DIRECTORY && -f $INSTALL_DIRECTORY/.zshrc ]] && export ZDOTDIR=$INSTALL_DIRECTORY"
-            echo -e $INSERT_TEXT | sudo tee -a /etc/zsh/zshenv > /dev/null
+            echo -e "$INSERT_TEXT" | sudo tee -a /etc/zsh/zshenv > /dev/null
             printf "/etc/zsh/zshenv will now set and export the ZDOTDIR variable.\n"
             printf "!!!IMPORTANT: YOU NEED TO MODIFY THIS FILE IF YOU CHANGE YOUR ZDOTDIR DIRECTORY LOCATION!!!\n" && sleep 1
             break

--- a/install.sh
+++ b/install.sh
@@ -309,7 +309,7 @@ for i in *; do
     # symlink alias and function files (they both begin with "doc_") so they can easily be modified from omz-files directory
     [[ "$i" = "doc_"* ]] && ln -sv $i $INSTALL_DIRECTORY/.oh-my-zsh/custom
     # copy nordvpn plugin to custom plugins directory (nordvpn plugin is yet to be included in oh-my-zsh outside of it's testing branch)
-    [[ "$i" = "nordvpn" ]] && cp -ru $i $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins
+    [[ -d $i ]] && cp -ru $i $INSTALL_DIRECTORY/.oh-my-zsh/custom/plugins
 done && sleep 1
 
 # recursively copy all dotfiles in the cloned repo directory (except .gitignore)

--- a/omz-files/doc_aliases.zsh
+++ b/omz-files/doc_aliases.zsh
@@ -4,8 +4,6 @@
 # this alias shouldn't be set unless on parrot distro
 if var=$(cat /etc/os-release | grep -wo 'parrot'); then
     alias sys-update='sudo parrot-upgrade'
-else
-    unalias sys-update
 fi
 
 # Useful aliases


### PR DESCRIPTION
- modified some minor things to better achieve compatibility with kali linux
- install.sh will now (after asking to backup existing zsh dotfiles) remove any existing in users home directory (if the install directory is different) and should be compatible enough to better work on kali linux
- nordvpn wasn't being copied to omz, now it will be
- .zshrc now checks if gh command is working before creating completions for it
- install script now correctly symlinks absolute paths to doc_aliases and doc_functions files.
